### PR TITLE
Updates to correct for latest code in libxlsxwriter.

### DIFF
--- a/lib/XLSX/Writer/Common.pm6
+++ b/lib/XLSX/Writer/Common.pm6
@@ -10,7 +10,7 @@ constant LIB is export = "xlsxwriter";
 constant MAX_ROWS = 1_048_576;
 constant MAX_COLS =  16_384;
 
-enum Color is export ( 
+enum Color is export (
     black => 0x1000000,
     blue => 0x0000FF,
     brown => 0x800000,
@@ -29,13 +29,17 @@ enum Color is export (
     yellow => 0xFFFF00
 );
 
-enum Error is export <no-error memory-malloc-failed creating-xlsx-file creating-tmpfile
-            zip-file-operation zip-file-add zip-close
-            null-parameter-ignored parameter-validation
-            sheetname-length-exceeded invalid-sheetname-character sheetname-already-used
-            string-length-exceeded-128 string-length-exceeded-255 string-length-exceeded-max
-            shared-string-index-not-found worksheet-index-out-of-range
-            max-number-urls-exceeded image-dimensions>;
+enum Error is export <
+    no-error                       memory-malloc-failed              creating-xlsx-file
+    creating-tmpfile               reading-tmpfile                   zip-file-operation
+    zip-parameter-error            zip-bad-file                      zip-internal-error
+    zip-file-add                   zip-close                         feature-not-supported
+    null-parameter-ignored         parameter-validation              sheetname-length-exceeded
+    invalid-sheetname-character    sheetname-start-end-apostrophe    sheetname-already-used
+    string-length-exceeded-32      string-length-exceeded-128        string-length-exceeded-255
+    string-length-exceeded-max     shared-string-index-not-found     worksheet-index-out-of-range
+    max-url-length-exceeded        max-number-urls-exceeded          image-dimensions
+>;
 
 enum Gridlines is export <hide-all-gridlines show-screen-gridlines show-print-gridlines show-all-gridlines>;
 
@@ -45,4 +49,3 @@ enum Script is export <<:superscript(1) subscript>>;
 
 subset RowRange of Range is export where { $_.is-int and $_.min >= 0 and $_.max < MAX_ROWS };
 subset ColRange of Range is export where { $_.is-int and $_.min >= 0 and $_.max < MAX_COLS };
-

--- a/lib/XLSX/Writer/Workbook.pm6
+++ b/lib/XLSX/Writer/Workbook.pm6
@@ -20,7 +20,7 @@ sub workbook_set_custom_property_boolean(XLSX::Writer::Workbook, Str, uint8) ret
 sub workbook_set_custom_property_datetime(XLSX::Writer::Workbook, Str, XLSX::Writer::DateTime) returns int32 is native(LIB) {*}
 sub workbook_define_name(XLSX::Writer::Workbook, Str, Str) returns int32 is native(LIB) {*}
 sub workbook_get_worksheet_by_name(XLSX::Writer::Workbook, Str) returns XLSX::Writer::Worksheet is native(LIB) {*}
-sub workbook_validate_worksheet_name(XLSX::Writer::Workbook, Str) returns int32 is native(LIB) {*}
+sub workbook_validate_sheet_name(XLSX::Writer::Workbook, Str) returns int32 is native(LIB) {*}
 
 method new(Str $path) {
     workbook_new($path)
@@ -47,7 +47,7 @@ method get-worksheet-by-name(Str:D $name) returns XLSX::Writer::Worksheet {
 }
 
 method validate-worksheet-name(Str:D $name) returns Error {
-    Error(workbook_validate_worksheet_name(self, $name))
+    Error(workbook_validate_sheet_name(self, $name))
 }
 
 method set-properties(XLSX::Writer::DocProperties $properties) returns Error {


### PR DESCRIPTION
No code errors, and tests now pass.

Previously, encountered:

```
Cannot locate symbol '(null)' in native library '(null)'
  in method setup at /home/cbwood/Projects/rakudobrew/versions/moar-blead/install/share/perl6/core/sources/947BDAB9F96E0E5FCCB383124F923A6BF6F8D76B (NativeCall) line 298
  in sub workbook_validate_worksheet_name at /home/cbwood/Projects/rakudobrew/versions/moar-blead/install/share/perl6/core/sources/947BDAB9F96E0E5FCCB383124F923A6BF6F8D76B (NativeCall) line 594
  in method validate-worksheet-name at /home/cbwood/Other_Projects/XLSX-Writer/lib/XLSX/Writer/Workbook.pm6 (XLSX::Writer::Workbook) line 50
  in block <unit> at t/basic.t line 11
```

